### PR TITLE
Fix logic for showing/hiding scheduled changes with a channel filter …

### DIFF
--- a/ui/src/utils/rules.js
+++ b/ui/src/utils/rules.js
@@ -1,0 +1,34 @@
+// test me in local dev too!
+const ruleMatchesChannel = (rule, channel) => {
+  // we support globs at the end of a channel only, hence
+  // splitting and taking the first part
+  const matchesGlob = (r, c) =>
+    r && r.includes('*') && c.startsWith(r.split('*')[0]);
+  const ruleChannelMatches =
+    // empty or absent channel matches anything
+    // however, a rule could also be non-existent
+    // (if a scheduled change is an insert)
+    // in this case, channel will be undefined, and we should _never_
+    // match on that, otherwise non-existent rules would show up
+    // on all filters.
+    rule.channel === null ||
+    rule.channel === '' ||
+    rule.channel === channel ||
+    matchesGlob(rule.channel, channel);
+  // if a scheduled change does not exist at all
+  // we never want this to match, otherwise all rules
+  // without scheduled changes will always match any filter
+  const scChannelMatches = rule.scheduledChange
+    ? rule.scheduledChange.channel === null ||
+      rule.scheduledChange.channel === '' ||
+      rule.scheduledChange.channel === channel ||
+      matchesGlob(rule.scheduledChange.channel, channel)
+    : false;
+
+  return ruleChannelMatches || scChannelMatches;
+};
+
+export {
+  // eslint-disable-next-line import/prefer-default-export
+  ruleMatchesChannel,
+};

--- a/ui/src/views/Rules/ListRules/index.jsx
+++ b/ui/src/views/Rules/ListRules/index.jsx
@@ -68,6 +68,7 @@ import { withUser } from '../../../utils/AuthContext';
 import remToPx from '../../../utils/remToPx';
 import elementsHeight from '../../../utils/elementsHeight';
 import Snackbar from '../../../components/Snackbar';
+import { ruleMatchesChannel } from '../../../utils/rules';
 
 const ALL = 'all';
 const useStyles = makeStyles(theme => ({
@@ -452,32 +453,13 @@ function ListRules(props) {
       const [productFilter, channelFilter] = productChannelQueries;
       const ruleProduct =
         rule.product || (rule.scheduledChange && rule.scheduledChange.product);
-      const ruleScheduledChangeChannel =
-        rule.scheduledChange && rule.scheduledChange.channel;
-      let ruleChannel;
 
       if (ruleProduct !== productFilter) {
         return false;
       }
 
-      if (ruleScheduledChangeChannel) {
-        if (ruleScheduledChangeChannel.includes('*')) {
-          ruleChannel = rule.channel && ruleScheduledChangeChannel;
-        } else {
-          ruleChannel = ruleScheduledChangeChannel && rule.channel;
-        }
-      } else {
-        ruleChannel = rule.channel;
-      }
-
-      if (channelFilter) {
-        if (ruleChannel.indexOf('*') === -1) {
-          if (ruleChannel !== channelFilter) {
-            return false;
-          }
-        } else if (!channelFilter.startsWith(ruleChannel.split('*')[0])) {
-          return false;
-        }
+      if (channelFilter && !ruleMatchesChannel(rule, channelFilter)) {
+        return false;
       }
 
       return true;

--- a/ui/test/ListRules_test.jsx
+++ b/ui/test/ListRules_test.jsx
@@ -1,0 +1,123 @@
+import { ruleMatchesChannel } from '../src/utils/rules';
+
+describe('channel matching', () => {
+  test('should match when only current rule matches', () => {
+    const result = ruleMatchesChannel(
+      {
+        channel: 'nightly',
+        scheduledChange: null,
+      },
+      'nightly'
+    );
+
+    expect(result).toBeTruthy();
+  });
+  test('should match when only scheduled change matches', () => {
+    const result = ruleMatchesChannel(
+      {
+        channel: 'nightly',
+        scheduledChange: {
+          channel: 'release',
+        },
+      },
+      'release'
+    );
+
+    expect(result).toBeTruthy();
+  });
+  test('should match when rule is null', () => {
+    const result = ruleMatchesChannel(
+      {
+        scheduledChange: {
+          channel: 'nightly',
+        },
+      },
+      'nightly'
+    );
+
+    expect(result).toBeTruthy();
+  });
+  test('should match when rule has glob', () => {
+    const rule = {
+      channel: 'nightly*',
+      scheduledChange: null,
+    };
+    const channels = ['nightly', 'nightly-cdntest', 'nightlytest'];
+    const results = channels.map(c => ruleMatchesChannel(rule, c));
+
+    expect(results).toEqual(expect.not.arrayContaining([false]));
+  });
+  test('should match when scheduled change has glob', () => {
+    const rule = {
+      channel: 'nightly',
+      scheduledChange: {
+        channel: 'beta*',
+      },
+    };
+    const channels = ['beta', 'beta-localtest'];
+    const results = channels.map(c => ruleMatchesChannel(rule, c));
+
+    expect(results).toEqual(expect.not.arrayContaining([false]));
+  });
+  test('should match when rule and scheduled change have null channel', () => {
+    const result = ruleMatchesChannel(
+      {
+        scheduledChange: {
+          channel: null,
+        },
+      },
+      'nightly'
+    );
+
+    expect(result).toBeTruthy();
+  });
+  test('should not match anything when rule is null', () => {
+    const result = ruleMatchesChannel(
+      {
+        scheduledChange: {
+          channel: 'nightly',
+        },
+      },
+      'beta'
+    );
+
+    expect(result).toBeFalsy();
+  });
+  test('should not match rule substring without a glob', () => {
+    const result = ruleMatchesChannel(
+      {
+        channel: 'nightly',
+        scheduledChange: null,
+      },
+      'nightly-cdntest'
+    );
+
+    expect(result).toBeFalsy();
+  });
+  test('should not match scheduled change substring without a glob', () => {
+    const result = ruleMatchesChannel(
+      {
+        channel: 'nightly',
+        scheduledChange: {
+          channel: 'beta',
+        },
+      },
+      'beta-cdntest'
+    );
+
+    expect(result).toBeFalsy();
+  });
+  test('should not match when rule and scheduled change are a different channel', () => {
+    const result = ruleMatchesChannel(
+      {
+        channel: 'nightly',
+        scheduledChange: {
+          channel: 'beta',
+        },
+      },
+      'release'
+    );
+
+    expect(result).toBeFalsy();
+  });
+});

--- a/ui/test/simple_test.js
+++ b/ui/test/simple_test.js
@@ -1,5 +1,0 @@
-describe('simple', () => {
-  it('should be sane', () => {
-    expect(false).not.toBe(true);
-  });
-});


### PR DESCRIPTION
…applied (#1790)

* Fix logic for showing/hiding scheduled changes with a channel filter applied

* Move rule channel matching logic out to a helper function

* Add some tests for ruleMatchesChannel; fix a bug

* Greatly simplify ruleMatchesChannel; fix some tests

* Lint fixes

* Simplify final block